### PR TITLE
fix bug where PFLOTRAN ver param is unused

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #build pflotran
 FROM ubuntu:20.04 as pflotran-build
 ARG PETSC_VERSION=v3.13
-ARG PFLOTRAN_VERSION=v3
+ARG PFLOTRAN_VERSION=v3.0
 WORKDIR /build
 COPY ./ubuntu-pflotran-build-deps.sh .
 RUN ./ubuntu-pflotran-build-deps.sh 

--- a/build-pflotran.sh
+++ b/build-pflotran.sh
@@ -4,10 +4,10 @@ export PETSC_DIR=`realpath petsc`
 export PETSC_ARCH=arch-linux2-c-opt
 if [ -z "$1" ] 
 then
-  PFLOTRAN_REF=$1
   print "You must specify the PFLOTRAN version (get ref) as the first argument"
   exit 1
 fi
+PFLOTRAN_REF=$1
 git clone https://bitbucket.org/pflotran/pflotran
 cd pflotran
 git checkout $PFLOTRAN_REF


### PR DESCRIPTION
We were building based on the HEAD of the master branch and not based on v3. The current difference should be inconsequential but we want to ensure a pinned PFLOTRAN version